### PR TITLE
Prevent attachment of duplicate event handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0-alpha3'
+    classpath 'com.android.tools.build:gradle:2.1.0'
     classpath 'me.tatarka:gradle-retrolambda:3.2.4'
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/lib/src/main/java/org/js/cycle/android/DomDriver.java
+++ b/lib/src/main/java/org/js/cycle/android/DomDriver.java
@@ -42,7 +42,12 @@ public final class DomDriver implements Driver {
     final ArrayList<View> focusables = touchInterceptor.getFocusables(View.FOCUS_FORWARD);
     for (View focusable: focusables) {
       if (focusable instanceof EditText) {
-        ((EditText) focusable).addTextChangedListener(new DomTextWatcher((EditText) focusable));
+        final EditText editText = (EditText) focusable;
+        if (editText.getTag() == null || !(editText.getTag() instanceof DomTextWatcher)) {
+          DomTextWatcher domTextWatcher = new DomTextWatcher(editText);
+          editText.addTextChangedListener(domTextWatcher);
+          editText.setTag(domTextWatcher);
+        }
       }
     }
   }


### PR DESCRIPTION
Fix for a problem I introduced with previous PR. Every render new listeners were added to EditTexts, even if they already attached.

Not the most elegant solution, but this way of adding listeners to all EditTexts does not scale to other View subclasses and listeners anyway. I think an approach of attaching listeners on demand (i.e. in the `.select()` and/or `.events()` methods. Maybe it's even interesting to look at [RxBinding](https://github.com/JakeWharton/RxBinding)
